### PR TITLE
Set pool creation fee constant to zero

### DIFF
--- a/programs/amm/src/instructions/create_pool.rs
+++ b/programs/amm/src/instructions/create_pool.rs
@@ -1,6 +1,7 @@
 use crate::error::ErrorCode;
 use crate::states::*;
 use crate::{libraries::tick_math, util};
+use crate::states::POOL_CREATION_FEE_LAMPORTS;
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 // use solana_program::{program::invoke_signed, system_instruction};
@@ -128,6 +129,8 @@ pub struct CreatePool<'info> {
 }
 
 pub fn create_pool(ctx: Context<CreatePool>, sqrt_price_x64: u128, open_time: u64) -> Result<()> {
+    // creation fee is set to zero by default. the constant is kept for compatibility
+    let _creation_fee = POOL_CREATION_FEE_LAMPORTS;
     let mint0_associated_is_initialized = util::support_mint_associated_is_initialized(
         &ctx.remaining_accounts,
         &ctx.accounts.token_mint_0,

--- a/programs/amm/src/states/pool.rs
+++ b/programs/amm/src/states/pool.rs
@@ -21,6 +21,8 @@ pub const POOL_REWARD_VAULT_SEED: &str = "pool_reward_vault";
 pub const POOL_TICK_ARRAY_BITMAP_SEED: &str = "pool_tick_array_bitmap_extension";
 // Number of rewards Token
 pub const REWARD_NUM: usize = 3;
+/// Fee charged when creating a new pool. Set to zero to disable
+pub const POOL_CREATION_FEE_LAMPORTS: u64 = 0;
 
 #[cfg(feature = "paramset")]
 pub mod reward_period_limit {


### PR DESCRIPTION
## Summary
- add POOL_CREATION_FEE_LAMPORTS constant in pool state and set to 0
- reference constant in create_pool instruction

## Testing
- `cargo check --workspace` *(fails: failed to get `uint` as a dependency, network error)*